### PR TITLE
example of inf loop caused by useEffect

### DIFF
--- a/section 11 handling side effects & working with the useEffect Hook/01-starting-project/src/App.jsx
+++ b/section 11 handling side effects & working with the useEffect Hook/01-starting-project/src/App.jsx
@@ -67,7 +67,7 @@ function App() {
     setPickedPlaces((prevPickedPlaces) =>
       prevPickedPlaces.filter((place) => place.id !== selectedPlace.current)
     );
-    setModalIsOpen(false);
+    // setModalIsOpen(false);
 
     const storedIds = JSON.parse(localStorage.getItem('selectedPlaces')) || [];
     localStorage.setItem('selectedPlaces', JSON.stringify(storedIds.filter((id) => id !== selectedPlace.current)));

--- a/section 11 handling side effects & working with the useEffect Hook/01-starting-project/src/components/DeleteConfirmation.jsx
+++ b/section 11 handling side effects & working with the useEffect Hook/01-starting-project/src/components/DeleteConfirmation.jsx
@@ -11,7 +11,7 @@ export default function DeleteConfirmation({ onConfirm, onCancel }) {
       console.log('TIMER CLEARED');
       clearTimeout(timer);
     }
-  },[])
+  },[onConfirm])
 
   return (
     <div id="delete-confirmation">


### PR DESCRIPTION
This can be an example of infinite loop caused by useEffect if pass a function shouldn't be track by useEffect.

Infinite loop reason:
Case : 
1. User wants to delete and open modal and doesnt click confirm.
2. After 3 sec, it will automatically run `onConfirm` in DeleteConfirmation.
3. This will trigger handleRemovePlace(onConfirm) in App.jsx, and will setPickedPlace, which causes the app to re-render.
4. App() will recreate handleRemovePlace(onConfirm)
5. DeleteConfirmation detects onConfirm changes and re-execute useEffect
6. Repeat 1-5

